### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
-CMRI KEYWORD1
-check KEYWORD2
-setInitHandler KEYWORD2
-setInputHandler KEYWORD2
-setOutputHandler KEYWORD2
-addDebugStream KEYWORD2
-printSummary KEYWORD2
+CMRI	KEYWORD1
+check	KEYWORD2
+setInitHandler	KEYWORD2
+setInputHandler	KEYWORD2
+setOutputHandler	KEYWORD2
+addDebugStream	KEYWORD2
+printSummary	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords